### PR TITLE
Add missing test assert for CSharp

### DIFF
--- a/CSharp/Parrot.Tests/ParrotTest.cs
+++ b/CSharp/Parrot.Tests/ParrotTest.cs
@@ -22,6 +22,7 @@ namespace Parrot.Tests
         public void GetSpeedNorwegianBlueParrot_not_nailed_high_voltage()
         {
             var parrot = new Parrot(ParrotTypeEnum.NORWEGIAN_BLUE, 0, 4, false);
+            Assert.Equal(24.0, parrot.GetSpeed());
         }
 
         [Fact]


### PR DESCRIPTION
One of the tests did not have the Assert statement