### PR TITLE
fix: build.gradle is incompatible with gradle 7

### DIFF
--- a/Java/build.gradle
+++ b/Java/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'java'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    // Use jcenter for resolving your dependencies.
+    // Use maven central for resolving your dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
     // Use JUnit test framework
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
In the Java project gradle 7.3.3 reports an error, because testCompile is not supported any longer. Instead we have to use testImplementation.

In addition I have switched to mavenCentral, because jcenter is deprecated ([see Gradle Blog](https://blog.gradle.org/jcenter-shutdown)) and updated junit to 4.13.2.