### PR TITLE
Swift tweaks

### DIFF
--- a/Swift/.gitignore
+++ b/Swift/.gitignore
@@ -1,23 +1,18 @@
-# Ios
-DerivedData
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-xcuserdata
-*.xccheckout
-*.moved-aside
-*.xcuserstate
-*.xcscmblueprint
-*.hmap
-*.ipa
-*.app.dSYM.zip
-*.xcarchive
-*.xcarchive.zip
+# Extra folder created by Xcode
+.swiftpm/
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos,swiftpackagemanager,xcode
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,swiftpackagemanager,xcode
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
 
 # Thumbnails
 ._*
@@ -29,3 +24,41 @@ xcuserdata
 .TemporaryItems
 .Trashes
 .VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### SwiftPackageManager ###
+Packages
+.build/
+xcuserdata
+DerivedData/
+*.xcodeproj
+
+
+### Xcode ###
+## User settings
+xcuserdata/
+
+## Xcode 8 and earlier
+*.xcscmblueprint
+*.xccheckout
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,swiftpackagemanager,xcode

--- a/Swift/Parrot/Parrot.swift
+++ b/Swift/Parrot/Parrot.swift
@@ -13,7 +13,7 @@ class Parrot {
         self.isNailed = isNailed
     }
 
-    var speed: Double {
+    func speed() -> Double {
         switch type {
         case .european:
             return baseSpeed

--- a/Swift/Parrot/Parrot.swift
+++ b/Swift/Parrot/Parrot.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 class Parrot {
-    private let parrotType: ParrotType
+    private let type: ParrotType
     private let numberOfCoconuts: Int
     private let voltage: Double
     private let isNailed: Bool
 
-    init(_ parrotType: ParrotType, numberOfCoconuts: Int, voltage: Double, isNailed: Bool) {
-        self.parrotType = parrotType
+    init(_ type: ParrotType, numberOfCoconuts: Int, voltage: Double, isNailed: Bool) {
+        self.type = type
         self.numberOfCoconuts = numberOfCoconuts
         self.voltage = voltage
         self.isNailed = isNailed
     }
 
     var speed: Double {
-        switch parrotType {
+        switch type {
         case .european:
             return baseSpeed
 

--- a/Swift/ParrotTests/ParrotTests.swift
+++ b/Swift/ParrotTests/ParrotTests.swift
@@ -3,36 +3,36 @@ import XCTest
 class ParrotTests: XCTestCase {
     func testSpeedOfEuropeanParrot() throws {
         let parrot = Parrot(.european, numberOfCoconuts: 0, voltage: 0.0, isNailed: false)
-        XCTAssertEqual(parrot.speed, 12.0)
+        XCTAssertEqual(parrot.speed(), 12.0)
     }
 
     func testSpeedOfAfricanParrot_with_one_coconut() throws {
         let parrot = Parrot(.african, numberOfCoconuts: 1, voltage: 0.0, isNailed: false)
-        XCTAssertEqual(parrot.speed, 3.0)
+        XCTAssertEqual(parrot.speed(), 3.0)
     }
 
     func testSpeedOfAfricanParrot_with_two_coconuts() throws {
         let parrot = Parrot(.african, numberOfCoconuts: 2, voltage: 0.0, isNailed: false)
-        XCTAssertEqual(parrot.speed, 0.0)
+        XCTAssertEqual(parrot.speed(), 0.0)
     }
 
     func testSpeedOfAfricanParrot_with_no_coconuts() throws {
         let parrot = Parrot(.african, numberOfCoconuts: 0, voltage: 0.0, isNailed: false)
-        XCTAssertEqual(parrot.speed, 12.0)
+        XCTAssertEqual(parrot.speed(), 12.0)
     }
 
     func testSpeedOfNorwegianBlueParrot_nailed() throws {
         let parrot = Parrot(.norwegianBlue, numberOfCoconuts: 0, voltage: 0.0, isNailed: true)
-        XCTAssertEqual(parrot.speed, 0.0)
+        XCTAssertEqual(parrot.speed(), 0.0)
     }
 
     func testSpeedOfNorwegianBlueParrot_not_nailed() throws {
         let parrot = Parrot(.norwegianBlue, numberOfCoconuts: 0, voltage: 1.5, isNailed: false)
-        XCTAssertEqual(parrot.speed, 18.0)
+        XCTAssertEqual(parrot.speed(), 18.0)
     }
 
     func testSpeedOfNorwegianBlueParrot_not_nailed_high_voltage() throws {
         let parrot = Parrot(.norwegianBlue, numberOfCoconuts: 0, voltage: 4.0, isNailed: false)
-        XCTAssertEqual(parrot.speed, 24.0)
+        XCTAssertEqual(parrot.speed(), 24.0)
     }
 }


### PR DESCRIPTION
Sorry, I changed my mind about some changes I'd made:
- Renamed `parrotType` back to just `type`. Using the same name makes it easier to discuss across languages.
- Computed properties imply constant time. We can't guarantee that for future parrots, so I changed `speed` from a computed property back to a method.

Also updated the Swift-level gitignore