### PR TITLE
PHP: Fix ecs error

### DIFF
--- a/PHP/src/Parrot.php
+++ b/PHP/src/Parrot.php
@@ -32,6 +32,9 @@ class Parrot
         };
     }
 
+    /**
+     * @throws Exception
+     */
     public function getCry(): string
     {
         return match ($this->type) {

--- a/PHP/src/Parrot.php
+++ b/PHP/src/Parrot.php
@@ -32,6 +32,16 @@ class Parrot
         };
     }
 
+    public function getCry(): string
+    {
+        return match ($this->type) {
+            ParrotTypeEnum::EUROPEAN => 'Sqoork!',
+            ParrotTypeEnum::AFRICAN => 'Sqaark!',
+            ParrotTypeEnum::NORWEGIAN_BLUE => $this->voltage > 0 ? 'Bzzzzzz' : '...',
+            default => throw new Exception('Should be unreachable'),
+        };
+    }
+
     private function getBaseSpeedWith(float $voltage): float
     {
         return min(24.0, $voltage * $this->getBaseSpeed());
@@ -45,15 +55,5 @@ class Parrot
     private function getBaseSpeed(): float
     {
         return 12.0;
-    }
-
-    public function getCry(): string
-    {
-        return match ($this->type) {
-            ParrotTypeEnum::EUROPEAN => 'Sqoork!',
-            ParrotTypeEnum::AFRICAN => 'Sqaark!',
-            ParrotTypeEnum::NORWEGIAN_BLUE => $this->voltage > 0 ? 'Bzzzzzz' : '...',
-            default => throw new Exception('Should be unreachable'),
-        };
     }
 }


### PR DESCRIPTION
@emilybache - fixed error reported by ECS (ordering of functions in Parrot class) after adding getCry method. 

All tests (phpunit, phpstan and check-cs) are now passing and back to green. 

Thanks!