### PR TITLE
Upgrade gradle version to use java21

### DIFF
--- a/Java/gradle/wrapper/gradle-wrapper.properties
+++ b/Java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/Kotlin/build.gradle
+++ b/Kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.4.10"
+    id "org.jetbrains.kotlin.jvm" version "1.9.20"
 }
 
 repositories {

--- a/Kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/Kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Wed Jun 24 17:17:39 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Gradle version to 8.5 to use Java21. 
- For version compatibility, see the [Gradle official documentation](https://docs.gradle.org/current/userguide/compatibility.html).