### PR TITLE
[ruby] Add `Gemfile.lock` to `.gitignore`

### DIFF
--- a/Ruby/.gitignore
+++ b/Ruby/.gitignore
@@ -4,3 +4,4 @@
 .buildpath
 .loadpath
 .settings
+Gemfile.lock


### PR DESCRIPTION
Running `bundle` causes this to be generated.

(committing a `Gemfile.lock` would also be a reasonable approach).