### PR TITLE
[JavaScript] Add getCry method and tests to match C# version

### DIFF
--- a/JavaScript/src/__tests__/parrot.spec.js
+++ b/JavaScript/src/__tests__/parrot.spec.js
@@ -26,6 +26,12 @@ describe("Parrot", function () {
     });
 
     test("get speed norwegian blue parrot nailed", function () {
+        const parrot = new Parrot(PARROT_TYPES.NORWEGIAN_BLUE, 0, 0, true);
+
+        expect(parrot.getSpeed()).toBe(0);
+    });
+
+    test("get speed norwegian blue parrot nailed with voltage", function () {
         const parrot = new Parrot(PARROT_TYPES.NORWEGIAN_BLUE, 0, 1.5, true);
 
         expect(parrot.getSpeed()).toBe(0);
@@ -41,5 +47,29 @@ describe("Parrot", function () {
         const parrot = new Parrot(PARROT_TYPES.NORWEGIAN_BLUE, 0, 4, false);
 
         expect(parrot.getSpeed()).toBe(24);
+    });
+
+    test("get cry of european parrot", function () {
+        const parrot = new Parrot(PARROT_TYPES.EUROPEAN, 0, 0, false);
+
+        expect(parrot.getCry()).toBe("Sqoork!");
+    });
+
+    test("get cry of african parrot", function () {
+        const parrot = new Parrot(PARROT_TYPES.AFRICAN, 2, 0, false);
+
+        expect(parrot.getCry()).toBe("Sqaark!");
+    });
+
+    test("get cry norwegian blue parrot high voltage", function () {
+        const parrot = new Parrot(PARROT_TYPES.NORWEGIAN_BLUE, 0, 4, false);
+
+        expect(parrot.getCry()).toBe("Bzzzzzz");
+    });
+
+    test("get cry norwegian blue parrot no voltage", function () {
+        const parrot = new Parrot(PARROT_TYPES.NORWEGIAN_BLUE, 0, 0, false);
+
+        expect(parrot.getCry()).toBe("...");
     });
 });

--- a/JavaScript/src/parrot.js
+++ b/JavaScript/src/parrot.js
@@ -35,4 +35,16 @@ export class Parrot {
     getBaseSpeed() {
         return 12;
     }
+
+    getCry() {
+        switch (this.type) {
+            case PARROT_TYPES.EUROPEAN:
+                return "Sqoork!";
+            case PARROT_TYPES.AFRICAN:
+                return "Sqaark!";
+            case PARROT_TYPES.NORWEGIAN_BLUE:
+                return this.voltage > 0 ? "Bzzzzzz" : "...";
+        }
+        throw new Error("Should be unreachable");
+    }
 }


### PR DESCRIPTION
## Summary
- Add `getCry()` method to the JavaScript `Parrot` class, matching the existing C# implementation
- Add corresponding tests for all three parrot types (European, African, Norwegian Blue with/without voltage)
- Add missing speed test for nailed Norwegian Blue with no voltage

The JavaScript version was missing the `getCry()` method and its tests that are present in the C# version. This brings the JS kata to feature parity with C#.